### PR TITLE
Use mime from serveStatic

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-var mime = require("mime");
 var serveStatic = require("serve-static");
+var mime = serveStatic.mime;
 
 module.exports = expressStaticGzip;
 


### PR DESCRIPTION
Don't load mime by ourselves, because the serveStatic module already exports it:

```
module.exports = serveStatic
module.exports.mime = send.mime
```

This way, we can configure mime types at a single place, e.g.:
``` 
express.static.mime.define({'application/x-sqlite3': ['db']});
```

(Not included in pull request: removing mime dependency from package.json)
