### PR TITLE
chore: check if folderpath exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -124,6 +124,9 @@ function expressStaticGzip(rootFolder, options) {
      * @param {string} folderPath
      */
     function findAllCompressionFiles(fs, folderPath) {
+        // check if folder exists
+        if (!fs.existsSync(folderPath))  return; 
+        
         var files = fs.readdirSync(folderPath);
         //iterate all files in the current folder
         for (var i = 0; i < files.length; i++) {


### PR DESCRIPTION
### What does this PR do?
This PR will check if the rootFolder passed to expressStaticGzip exist. If it doesn't, it exit the `findAllCompressionFiles` function.

### Why is this important?
In my test environment, the static folder doesn't exist so the test fails with a scan directory error.

Cheers! 