### PR TITLE
Handle url-encoded file path

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function expressStaticGzip(rootFolder, options) {
         var acceptEncoding = req.header("accept-encoding");
 
         //test if any compression is available 
-        var matchedFile = files[req.path];
+        var matchedFile = files[decodeURIComponent(req.path)];
         if (matchedFile) {
             //as long as there is any compression available for this file, add the Vary Header (used for caching proxies)
             res.setHeader("Vary", "Accept-Encoding");

--- a/test/e2e.spec.js
+++ b/test/e2e.spec.js
@@ -168,6 +168,15 @@ describe('End to end', function () {
         });
     });
 
+    it('should handle url encoded path', function(){
+        setupServer();
+
+        return requestFile("/filename with spaces.txt", { 'accept-encoding': 'gzip'}).then(resp => {
+            expect(resp.statusCode).to.equal(200);
+            expect(resp.body).to.equal('"filename with spaces.txt.gz"');
+        });
+    });
+
     /**
      * 
      * @param {string} fileName 

--- a/test/wwwroot/filename with spaces.txt.gz
+++ b/test/wwwroot/filename with spaces.txt.gz
@@ -1,0 +1,1 @@
+"filename with spaces.txt.gz"


### PR DESCRIPTION
Hi,
This is a fix to handle encoded path when testing if a compressed file is available.  
With the current release it is not possible to use compression if a filename contains any special character.  
I think decoding `req.path` is the proper thing to do.