### PR TITLE
Rename middleware function to expressStaticGzip for router debug clarity

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function expressStaticGzip(rootFolder, options) {
         findAllCompressionFiles(require("fs"), rootFolder);
     }
 
-    return function middleware(req, res, next) {
+    return function expressStaticGzip(req, res, next) {
         changeUrlFromEmptyToIndexHtml(req);
 
         //get browser's' supported encodings


### PR DESCRIPTION
When using `debug` `express:router`, this new function name correctly identifies the middleware.

ref: [https://expressjs.com/fr/guide/debugging.html](https://expressjs.com/fr/guide/debugging.html)