### PR TITLE
Handle identity and q=0

### DIFF
--- a/test/encoding-selection.spec.js
+++ b/test/encoding-selection.spec.js
@@ -65,4 +65,9 @@ describe('encoding-selection', function () {
         const result = findEncoding('gzip; q=0.6, deflate; q=1, br;q=0.5', [GZIP, BROTLI, DEFLATE], ['br']);
         expect(result).to.be.deep.equal(BROTLI);
     });
+
+    it('should treat identity as null', function () {
+        const result = findEncoding('identity;q=1, gzip;q=0.5', [GZIP]);
+        expect(result).to.be.null;
+    });
 });

--- a/test/encoding-selection.spec.js
+++ b/test/encoding-selection.spec.js
@@ -70,4 +70,9 @@ describe('encoding-selection', function () {
         const result = findEncoding('identity;q=1, gzip;q=0.5', [GZIP]);
         expect(result).to.be.null;
     });
+
+    it('should not use encodings with q=0', function () {
+        const result = findEncoding('br;q=1, *;q=0', [GZIP]);
+        expect(result).to.be.null;
+    });
 });

--- a/util/encoding-selection.js
+++ b/util/encoding-selection.js
@@ -1,5 +1,8 @@
 // see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding
 
+// Indicates the identity function (i.e. no compression, nor modification)
+const IDENTITY = 'identity';
+
 /**
  * 
  * @param {string} acceptEncoding Content of the accept-encoding header
@@ -18,6 +21,9 @@ function findEncoding(acceptEncoding, availableCompressions, preference) {
 
 function findFirstMatchingCompression(sortedEncodingList, availableCompressions) {
     for (const encoding of sortedEncodingList) {
+        if (encoding === IDENTITY) {
+            return null;
+        }
         for (let i = 0; i < availableCompressions.length; i++) {
             if (encoding === '*' || encoding === availableCompressions[i].encodingName) {
                 return availableCompressions[i];

--- a/util/encoding-selection.js
+++ b/util/encoding-selection.js
@@ -1,7 +1,7 @@
 // see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding
 
 // Indicates the identity function (i.e. no compression, nor modification)
-const IDENTITY = 'identity';
+let IDENTITY = 'identity';
 
 /**
  * 
@@ -64,6 +64,7 @@ function parseEncoding(acceptedEncoding) {
     return acceptedEncoding.split(',')
         .map(encoding => parseQuality(encoding))
         .sort((encodingA, encodingB) => encodingB.q - encodingA.q)
+        .filter(encoding => encoding.q > 0)
         .map(encoding => encoding.name);
 }
 

--- a/util/encoding-selection.js
+++ b/util/encoding-selection.js
@@ -1,7 +1,7 @@
 // see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding
 
 // Indicates the identity function (i.e. no compression, nor modification)
-let IDENTITY = 'identity';
+const IDENTITY = 'identity';
 
 /**
  * 


### PR DESCRIPTION
In chrome, if we on a page have:

```
  <audio src="mysong.mp3" />
```

we get a request with this header:

`Accept-Encoding: identity;q=1, *;q=0`

What chrome means that it _absolutely_ wants the uncompressed file (I guess to be able to stream the contents). But a bug in `express-static-gzip` means we get the compressed stream.

This PR fixes two problems:

* `identity` isn't currently handled.
* `*;q=0` is interpreted as `*`