### PR TITLE
Add types and files fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "2.1.0",
   "description": "simple wrapper on top of express.static, that allows serving pre-gziped files",
   "main": "index.js",
+  "types": "index.d.ts",
+  "files": ["util/", "LICENSE.md", "README.md", "index.d.ts"],
   "scripts": {
     "test": "mocha test/*.spec.js"
   },


### PR DESCRIPTION
Specifying [the files whitelist](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#files) will prevent things like the test folder from being included in the published package. _Please do verify_ that I included everything necessary by checking the output of `npm pack --dry-run`.

About the typings field I added in package.json, for this project, [this is not necessary, but recommended](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package). Below is the relevant statement in the TypeScript docs:

> Also note that if your main declaration file is named index.d.ts and lives at the root of the package (next to index.js) you do not need to mark the "types" property, though it is advisable to do so.

One recent/new benefit of specifying it is this:

https://github.blog/changelog/2020-12-16-npm-displays-packages-with-bundled-typescript-declarations/