### PR TITLE
Add option to prevent throw error when not found matching file

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ When the middleware is created it will check the given root folder and all subfo
     
     This will be forwarded to the underlying `serveStatic` instance used by `expressStaticGzip`
 
+* **`throwIfNotFoundFile`**: boolean (default: **true**)
+    
+    Allow to prevent throw error if server can't find any file that match request path
+
 # Behavior warning
 
 In default mode a request for "/" or "\<somepath\>/" will serve index.html as compressed version. This could lead to **complications if you are serving a REST API** from the same path, when *express-server-static* is registered before your API. 

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,7 +60,14 @@ declare namespace expressStaticGzip {
          * This will be forwarded to the underlying `serveStatic` instance used by `expressStaticGzip`.
          * @default null
          */
-        serveStatic?: serverStatic.ServeStaticOptions
+        serveStatic?: serverStatic.ServeStaticOptions;
+
+        /**
+         * Allow to prevent throw error if server can't find any file that match request path
+         * Options for FileSystem.statSync - https://nodejs.org/api/fs.html#fs_fs_statsync_path_options
+         * @default true
+         */
+        throwIfNotFoundFile?: boolean;
     }
 
     interface Compression {

--- a/index.js
+++ b/index.js
@@ -90,7 +90,10 @@ function expressStaticGzipMiddleware(root, options) {
         var filesInDirectory = fs.readdirSync(directoryPath);
         for (var i = 0; i < filesInDirectory.length; i++) {
             var filePath = directoryPath + "/" + filesInDirectory[i];
-            var stats = fs.statSync(filePath);
+            var stats = fs.statSync(filePath, { throwIfNoEntry: opts.throwIfNotFoundFile });
+            if (!stats) {
+                continue;
+            }
             if (stats.isDirectory()) {
                 findCompressedFilesInDirectory(filePath);
             } else {

--- a/util/options.js
+++ b/util/options.js
@@ -15,7 +15,8 @@ function sanitizeOptions(userOptions) {
      * @type {expressStaticGzip.ExpressStaticGzipOptions}
      */
     let sanitizedOptions = {
-        index: getIndexValue(userOptions)
+        index: getIndexValue(userOptions),
+        throwIfNotFoundFile: true,
     }
 
     if (typeof (userOptions.enableBrotli) !== "undefined") {
@@ -28,6 +29,10 @@ function sanitizeOptions(userOptions) {
 
     if (typeof (userOptions.orderPreference) === "object") {
         sanitizedOptions.orderPreference = userOptions.orderPreference;
+    }
+
+    if (typeof (userOptions.throwIfNotFoundFile) === "boolean") {
+        sanitizedOptions.throwIfNotFoundFile = userOptions.throwIfNotFoundFile;
     }
 
     prepareServeStaticOptions(userOptions, sanitizedOptions);


### PR DESCRIPTION
Hi author,

Recently I used this middleware, I had a issue that when a request for a sourcemap file not found in server (because I deleted it manually)

![error image!](https://imgur.com/ZKLTT7D.png "error image")

As I read in nodejs document here https://nodejs.org/api/fs.html#fs_fs_statsync_path_options
We could avoid this throw by skip it (as my case)

So I hope this PR would add a option for anyone have the same issue with me.

