### PR TITLE
Serve the index file only if the the original URL has trailing slash.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 let fs = require("fs");
+var parseUrl = require('parseurl')
 let serveStatic = require("serve-static");
 let sanitizeOptions = require("./util/options").sanitizeOptions;
 let findEncoding = require("./util/encoding-selection").findEncoding;
@@ -91,7 +92,7 @@ function expressStaticGzipMiddleware(root, options) {
 
   function changeUrlFromDirectoryToIndexFile(req) {
     const parts = req.url.split('?');
-    if (opts.index && parts[0].endsWith("/")) {
+    if (opts.index && parts[0].endsWith("/") && parseUrl.original(req).pathname.endsWith("/")) {
       parts[0] += opts.index;
       req.url = parts.length > 1 ? parts.join('?') : parts[0];
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.1.8",
       "license": "MIT",
       "dependencies": {
+        "parseurl": "^1.3.3",
         "serve-static": "^1.16.2"
       },
       "devDependencies": {
@@ -2471,6 +2472,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "parseurl": "^1.3.3",
     "serve-static": "^1.16.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This change makes the behaviour consistent with serve-static when redirects are enabled and non-root mount is used.

Fixes #68.