### PR TITLE
refactor(type): make options optional in type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for express-static-gzip 2.0
+// Type definitions for express-static-gzip 3.0.0
 /* =================== USAGE ===================
 
     import * as expressStaticGzip from "express-static-gzip";
@@ -15,7 +15,7 @@ import * as serverStatic from "serve-static";
  * @param root folder to staticly serve files from
  * @param options options to configure expressStaticGzip
  */
-declare function expressStaticGzip(root: string, options: expressStaticGzip.ExpressStaticGzipOptions): (req: any, res: any, next: any) => any;
+declare function expressStaticGzip(root: string, options?: expressStaticGzip.ExpressStaticGzipOptions): (req: any, res: any, next: any) => any;
 
 declare namespace expressStaticGzip {
 


### PR DESCRIPTION
According to the documentation and the control flow of the source code `expressStaticGzip` can be invoked without declaring the second parameter (`options`).

The type definition for Typescript denotes the `options`-parameter as mandatory, leading to type errors, and therefore should be defined as optional.