### PR TITLE
Fix malformed uri handling when res is not an express response

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,21 @@ let findEncoding = require("./util/encoding-selection").findEncoding;
 
 module.exports = expressStaticGzipMiddleware;
 
+function sendBadRequest(res, message) {
+  if (typeof res.status === "function" && typeof res.send === "function") {
+    res.status(400).send(message);
+    return;
+  }
+
+  res.statusCode = 400;
+
+  if (typeof res.setHeader === "function") {
+    res.setHeader("Content-Type", "text/plain; charset=utf-8");
+  }
+
+  res.end(message);
+}
+
 /**
  * Generates a middleware function to serve pre-compressed files. It is build on top of serveStatic.
  * The pre-compressed files need to be placed next to the original files, in the provided `root` directory.
@@ -34,7 +49,7 @@ function expressStaticGzipMiddleware(root, options) {
     try {
       path = decodeURIComponent(req.path);
     } catch (e) {
-      res.status(400).send(e.message);
+      sendBadRequest(res, e.message);
       return;
     }
 

--- a/test/e2e.spec.js
+++ b/test/e2e.spec.js
@@ -257,6 +257,31 @@ describe('End to end', function () {
       });
     });
 
+    it('should handle malformed uri with plain node response object', function () {
+        const middleware = serveStaticGzip(__dirname + '/wwwroot');
+        const req = {headers: {}, path: '/%c0', url: '/%c0'};
+        const res = {
+            statusCode: 200,
+            headers: {},
+            setHeader(name, value) {
+                this.headers[name] = value;
+            },
+            end(body) {
+                this.body = body;
+                this.ended = true;
+            }
+        };
+
+        middleware(req, res, () => {
+            throw new Error('next should not be called');
+        });
+
+        expect(res.statusCode).to.equal(400);
+        expect(res.headers['Content-Type']).to.equal('text/plain; charset=utf-8');
+        expect(res.body).to.equal('URI malformed');
+        expect(res.ended).to.equal(true);
+    });
+
     /**
      * 
      * @param {string} fileName 


### PR DESCRIPTION
Fixes #75. Keeps the `400` behaviour from #45, but avoids throwing a second exception when the response object is not a full Express response. Adds a regression test.